### PR TITLE
Fix `maybe-utils` dependency

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
-version = "0.3.4"
+version = "0.3.5"
 name = "stanza-toml"
 [dependencies]
 maybe-utils = "StanzaOrg/maybe-utils|0.1.4"

--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 version = "0.3.4"
 name = "stanza-toml"
 [dependencies]
-maybe-utils = "tylanphear/maybe-utils|0.1.3"
+maybe-utils = "StanzaOrg/maybe-utils|0.1.4"


### PR DESCRIPTION
This dependency was still pointing at `tylanphear/maybe-utils` instead of the canonical source `StanzaOrg/maybe-utils`. 

This also fixes the broken `maybe-utils` as of the `PeekSeq` introduction.