### PR TITLE
Bug Fixes and Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-build
+toml-tests
 .slm
 slm.lock
+
+.vscode/
+.envrc
+.stanza

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# TOML Parser / Writer
+
+This library provides a pure stanza implementation of a [TOML](https://toml.io) format parser/writer.
+
+# Using this library
+
+The easiest way to use this library is:
+
+1.  Use [slm](https://github.com/StanzaOrg/slm) to manage dependencies in your [stanza](https://lbstanza.org) project.
+    1.  slm add -git StanzaOrg/slm
+2.  Use a git submodule and manage dependencies manually.
+
+## Example:
+
+```stanza
+defn get-name-version (path:String) -> [String, String] :
+  val tab = table $ parse-file(path)
+  val name = tab["name"] as String
+  val version = tab["version"] as String
+  [name, version]
+```
+
+# Limitations
+
+This library currently does **not** support [inline arrays](https://toml.io/en/v1.0.0#array).
+
+```
+# Not Supported:
+args = [ "apple", "orange", "kiwi"]
+```
+
+It also does **not** support [RFC 3339 date-time](https://toml.io/en/v1.0.0#offset-date-time).
+
+```
+created = 1979-05-27T07:32:00
+```
+
+# Running the tests
+
+1.  Have [stanza](https://lbstanza.org/) installed and available on your `$PATH`.
+2.  Have [slm](https://github.com/StanzaOrg/slm) installed and available on your `$PATH`
+3.  You will also need `gcc` available on your `$PATH`
+
+Run:
+
+```
+$> slm build test
+$> ./toml-test
+```

--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
-version = "0.3.5"
+version = "0.4.0"
 name = "stanza-toml"
 [dependencies]
 maybe-utils.git = "StanzaOrg/maybe-utils"

--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,5 @@
 version = "0.3.5"
 name = "stanza-toml"
 [dependencies]
-maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
+maybe-utils.git = "StanzaOrg/maybe-utils"
+maybe-utils.version = "0.1.4"

--- a/src/file.stanza
+++ b/src/file.stanza
@@ -2,7 +2,6 @@ defpackage toml/file:
   import core
   import collections
   import toml/value
-  import toml/pair
   import toml/table
 
 public deftype TomlFile <: Seqable<KeyValue<String, TomlValue>>

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -1,3 +1,0 @@
-defpackage toml:
-  import core
-  import collections

--- a/src/pair.stanza
+++ b/src/pair.stanza
@@ -1,8 +1,0 @@
-defpackage toml/pair:
-  import core
-  import toml/value
-  import toml/table
-
-public defstruct TomlPair:
-  key: String
-  value: TomlValue

--- a/src/parser.stanza
+++ b/src/parser.stanza
@@ -4,7 +4,6 @@ defpackage toml/parser:
   import maybe-utils
   import toml/value
   import toml/file
-  import toml/pair
   import toml/table
   import toml/utils
 

--- a/src/parser.stanza
+++ b/src/parser.stanza
@@ -8,6 +8,15 @@ defpackage toml/parser:
   import toml/table
   import toml/utils
 
+public defstruct TomlParserError <: Exception :
+  file-name:String
+  line:Int
+  column:Int
+  msg:String|Printable
+
+defmethod print (o:OutputStream, e:TomlParserError):
+  print(o, "[%_:%~:%~]: error: %~" % [file-name(e), line(e), column(e), to-string(msg(e))])
+
 defstruct ParsePosition:
   offset: Int
   line: Int
@@ -32,7 +41,7 @@ defn peek (parser: Parser) -> Maybe<Char>:
 
 defn error (parser: Parser, msg: Printable) -> Void:
   val pos = position(parser)
-  fatal("[%_:%~:%~]: error: %~" % [file-name(parser), line(pos), column(pos), msg])
+  throw $ TomlParserError(file-name(parser), line(pos), column(pos), msg)
 
 defn error (parser: Parser, msg: String) -> Void:
   error(parser, "%_" % [msg])

--- a/src/parser.stanza
+++ b/src/parser.stanza
@@ -69,6 +69,18 @@ defn expect-newline (parser: Parser) -> False|Void:
     advance(parser)
   expect(parser, '\n')
 
+defn expect-newline-or-eof (parser:Parser) -> False|Void:
+  if peek(parser) == One('\r'):
+    advance(parser)
+  match(peek(parser)):
+    (c:One<Char>):
+      if value(c) == '\n':
+        advance(parser)
+      else:
+        error(parser, "Expected: `%~`\nGot: `%~`" % [value, peek(parser)])
+    (x:None):
+      false
+
 defn take-while (parser: Parser, pred: Char -> True|False) -> String:
   val s = StringBuffer()
   let loop ():
@@ -192,7 +204,7 @@ defn parse-table-inner (parser: Parser, table: TomlTable, root?: True|False) -> 
             skip-whitespace(parser)
           else if is-identifier(c) or c == '"':
             insert(table, parse-key-value(parser))
-            expect-newline(parser)
+            expect-newline-or-eof(parser)
           else:
             error(parser, "Unexpected character: '%_'" % [c])
         (_):

--- a/src/stanza.proj
+++ b/src/stanza.proj
@@ -1,7 +1,0 @@
-package toml/file   defined-in "file.stanza"
-package toml/pair   defined-in "pair.stanza"
-package toml/parser defined-in "parser.stanza"
-package toml/table  defined-in "table.stanza"
-package toml/test   defined-in "test.stanza"
-package toml/utils  defined-in "utils.stanza"
-package toml/value  defined-in "value.stanza"

--- a/src/table.stanza
+++ b/src/table.stanza
@@ -2,7 +2,6 @@ defpackage toml/table:
   import core
   import collections
   import toml/value
-  import toml/pair
   import maybe-utils
 
 public defstruct KeyAlreadyExistsError <: Exception :
@@ -97,6 +96,6 @@ public defn TomlTable (pairs: Seqable<KeyValue<String, TomlValue>>):
   func-name in [get-str?, get-int?, get-table?],
   out-type in [String, Int, TomlTable]
   ):
-  public defn func-name (t:TomlTable, key:String) -> Maybe<out-type> : 
+  public defn func-name (t:TomlTable, key:String) -> Maybe<out-type> :
     get?(t, key) $> map{_, {_ as out-type}}
 

--- a/src/table.stanza
+++ b/src/table.stanza
@@ -5,6 +5,18 @@ defpackage toml/table:
   import toml/pair
   import maybe-utils
 
+public defstruct KeyAlreadyExistsError <: Exception :
+  key:String
+
+defmethod print (o:OutputStream, e:KeyAlreadyExistsError) :
+  print(o, "key '%_' already exists in table" % [key(e)])
+
+public defstruct KeyIsNotATableError <: Exception :
+  key:String
+
+defmethod print (o:OutputStream, e:KeyIsNotATableError) :
+  print(o, "key '%_' is not a table" % [key(e)])
+
 public deftype TomlTable <: TomlValue & Seqable<KeyValue<String, TomlValue>>
 public defmulti set (t: TomlTable, key: String, value: TomlValue) -> False
 public defmulti get (t: TomlTable, key: String) -> TomlValue
@@ -30,8 +42,8 @@ public defn TomlTable ():
 
   new TomlTable:
     defmethod insert (this, entry: KeyValue<String, TomlValue>) -> False:
-      if contains?(key-indexes, key(entry)):
-        fatal("key `%_` already exists in table" % [key(entry)])
+      if contains?(keys(key-indexes), key(entry)):
+        throw $ KeyAlreadyExistsError(key(entry))
 
       val components = to-tuple(split(key(entry), ".", 2))
       if length(components) == 2:
@@ -40,7 +52,7 @@ public defn TomlTable ():
           (first-table?: One<TomlValue>):
             match(value!(first-table?)):
               (first-table: TomlTable): insert(first-table, components[1] => value(entry))
-              (_): fatal("key `%_` is not a table" % [key])
+              (_): throw $ KeyIsNotATableError(first-component)
           (_: None):
             val first-table = TomlTable()
             insert(first-table, components[1] => value(entry))
@@ -62,7 +74,7 @@ public defn TomlTable ():
             match(first-table: TomlTable):
               first-table[components[1]]
             else:
-              fatal("key `%_` is not a table" % [key])
+              throw $ KeyIsNotATableError(key)
           }
       else:
         get-entry(key)

--- a/src/table.stanza
+++ b/src/table.stanza
@@ -78,3 +78,13 @@ public defn TomlTable (pairs: Seqable<KeyValue<String, TomlValue>>):
   for pair in pairs do:
     insert(table, pair)
   table
+
+; Utility Functions for accesing data from the table.
+;  These are helpers
+#for (
+  func-name in [get-str?, get-int?, get-table?],
+  out-type in [String, Int, TomlTable]
+  ):
+  public defn func-name (t:TomlTable, key:String) -> Maybe<out-type> : 
+    get?(t, key) $> map{_, {_ as out-type}}
+

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -9,7 +9,8 @@ public defn is-digit (c: Char) -> True|False:
   '0' <= c and c <= '9'
 
 public defn is-identifier (c: Char) -> True|False:
-  is-ascii(c) or c == '-'
+  ; [A-Za-z0-9_-]
+  is-ascii(c) or is-digit(c) or c == '-' or c == '_'
 
 public defn is-whitespace (c: Char) -> True|False:
   c == ' ' or c == '\n' or c == '\r'

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,6 +1,7 @@
 include? ".slm/stanza.proj"
 pkg-cache: ".slm/pkg-cache"
 
+package toml defined-in "toml.stanza"
 packages toml/*  defined-in "src/"
 packages toml/tests/*  defined-in "tests/"
 

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,4 +1,7 @@
-include "src/stanza.proj"
+include? ".slm/stanza.proj"
+pkg-cache: ".slm/pkg-cache"
+
+packages toml/*  defined-in "src/"
 
 build-test test:
   inputs:

--- a/stanza.proj
+++ b/stanza.proj
@@ -2,8 +2,9 @@ include? ".slm/stanza.proj"
 pkg-cache: ".slm/pkg-cache"
 
 packages toml/*  defined-in "src/"
+packages toml/tests/*  defined-in "tests/"
 
 build-test test:
   inputs:
-    toml/test
-  o: "build/test"
+    toml/tests/basic
+  o: "toml-tests"

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(tests)
-defpackage toml/test:
+defpackage toml/tests/basic:
   import core
   import collections
   import toml/table

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -105,3 +105,30 @@ deftest no-newline-at-eof:
   #EXPECT(name == "no_new_line")
   val version = t["version"] as String
   #EXPECT(version == "0.1.0")
+
+deftest accessors:
+  val toml = table $ parse-string $ dedent $ \<>
+    foo = "bar"
+    bar = 1
+    [dependencies]
+    stanza-toml = "git@github.com:tylanphear/stanza-toml"
+    poet = "git@github.com:tylanphear/poet"
+  <>
+
+  #EXPECT(get-str?(toml, "non-existent") is None)
+  #EXPECT(get-int?(toml, "non-existent") is None)
+  #EXPECT(get-table?(toml, "non-existent") is None)
+
+  val uut-str = get-str?(toml, "foo")
+  #EXPECT(uut-str is One)
+  #EXPECT(value!(uut-str) == "bar")
+  
+  val uut-int = get-int?(toml, "bar")
+  #EXPECT(uut-int is One)
+  #EXPECT(value!(uut-int) == 1)
+
+  val uut-table = get-table?(toml, "dependencies")
+  #EXPECT(uut-table is One)
+  val cnt = length $ entries $ value!(uut-table)
+  #EXPECT(cnt == 2)
+

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -95,3 +95,13 @@ deftest empty-inline-table:
 deftest comments:
   val toml = table $ parse-string $ "# this is a comment\nfoo = \"bar\"\n"
   #EXPECT((toml["foo"] as String) == "bar")
+
+deftest no-newline-at-eof:
+  val t = table $ parse-string $ dedent $ \<>
+  name = "no_new_line"
+  version = "0.1.0"<>
+
+  val name = t["name"] as String
+  #EXPECT(name == "no_new_line")
+  val version = t["version"] as String
+  #EXPECT(version == "0.1.0")

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -159,3 +159,9 @@ deftest(errors) table-insert-error:
     #EXPECT(key(e) == "version")
   catch (e:Exception):
     #EXPECT("Unexpected Exception" == e)
+
+deftest inline-table-key-num:
+  ; TODO - this is a bug.
+  val toml = table $ parse-string $ "foo3 = { bar = { baz = 10, bang = \"hello\" } }\n"
+  #EXPECT(toml["foo3.bar.baz"] as Int == 10)
+  #EXPECT(toml["foo3.bar.bang"] as String == "hello")

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -132,3 +132,33 @@ deftest accessors:
   val cnt = length $ entries $ value!(uut-table)
   #EXPECT(cnt == 2)
 
+deftest parse-error-1:
+  try:
+    val data = parse-file("tests/invalid_1.toml")
+    #EXPECT("Reached Invalid Point" == to-string(data))
+  catch (e:TomlParserError):
+    #EXPECT(file-name(e) == "tests/invalid_1.toml")
+    #EXPECT(line(e) == 3)
+  catch (e:Exception):
+    #EXPECT("Wrong Type of Exception" == e)
+
+deftest(errors) table-insert-error:
+  val t = table $ parse-string $ dedent $ \<>
+    name= "no_new_line"
+    version = "0.1.0"<>
+
+  try:
+    insert(t, KeyValue("version", "0.2.0"))
+    #EXPECT("Reached Unexpected Code Position" == "")
+  catch (e:KeyAlreadyExistsError):
+    #EXPECT(key(e) == "version")
+  catch (e:Exception):
+    #EXPECT("Unexpected Exception" == e)
+
+  try:
+    t["version.patch"] = "qwer"
+    #EXPECT("Reached Unexpected Code Position" == "")
+  catch (e:KeyIsNotATableError):
+    #EXPECT(key(e) == "version")
+  catch (e:Exception):
+    #EXPECT("Unexpected Exception" == e)

--- a/tests/basic.stanza
+++ b/tests/basic.stanza
@@ -2,10 +2,7 @@
 defpackage toml/tests/basic:
   import core
   import collections
-  import toml/table
-  import toml/parser
-  import toml/value
-  import toml/file
+  import toml
 
 public defn dedent (str: String) -> String:
   defn trim-left (s: String):
@@ -122,7 +119,7 @@ deftest accessors:
   val uut-str = get-str?(toml, "foo")
   #EXPECT(uut-str is One)
   #EXPECT(value!(uut-str) == "bar")
-  
+
   val uut-int = get-int?(toml, "bar")
   #EXPECT(uut-int is One)
   #EXPECT(value!(uut-int) == 1)

--- a/tests/invalid_1.toml
+++ b/tests/invalid_1.toml
@@ -1,0 +1,3 @@
+name = "asdf"
+zxcv = 1
+[InvalidTable

--- a/toml.stanza
+++ b/toml.stanza
@@ -1,0 +1,8 @@
+defpackage toml:
+  import core
+  import collections
+
+  forward toml/file
+  forward toml/parser
+  forward toml/table
+  forward toml/value


### PR DESCRIPTION
This PR primarily:

1.  Fixes some bugs and inconveniences
    1.   Libraries like this probably should not call `fatal` - they probably want to throw an exception that can be caught.
    2.  Fixed bugs in the parser that made it not compliant with TOML v1.0 spec.
        1.  We don't support inline arrays yet - Made a note in the new README.  
2.  Fixed imports and the structure of the project. 
     1.  User now just needs to use `import toml` to use the library instead of multiple internal library packages.     
     
     